### PR TITLE
Update generate_preview scripts to disable casual clothes

### DIFF
--- a/blender 2.79/generate_previews.py
+++ b/blender 2.79/generate_previews.py
@@ -22,9 +22,6 @@ color_masks_dir = os.path.join(blend_file_directory, "color_masks")
 if not os.path.isdir(color_masks_dir):
   raise Exception("color_masks directory was not found.")
 preview_dir = os.path.join(blend_file_directory, "preview")
-casual_clothes_tex_path = os.path.join(blend_file_directory, "..", "linktexbci4.png")
-if not os.path.isfile(casual_clothes_tex_path):
-  raise Exception("Casual clothes texture (linktexbci4.png) was not found.")
 pupil_image_path = os.path.join(blend_file_directory, "hitomi.png")
 if not os.path.isfile(pupil_image_path):
   raise Exception("Pupil texture (hitomi.png) was not found.")
@@ -37,9 +34,46 @@ if not os.path.isfile(tex_headers_path):
 model_metadata_path = os.path.join(blend_file_directory, "metadata.txt")
 if not os.path.isfile(model_metadata_path):
   raise Exception("metadata.txt was not found.")
-casual_hair_model_path = os.path.join(blend_file_directory, "..", "katsura", "katsura.blend")
-if not os.path.isfile(casual_hair_model_path):
-  raise Exception("Casual hair model (katsura.blend) was not found.")
+
+# read the metadata file
+model_metadata = {}
+last_custom_colors_hash = None
+with open(model_metadata_path) as f:
+  for line in f.readlines():
+    match = re.search(r"^(\S[^\n\r:]*): (.+)$", line)
+    colors_hash_start_match = re.search(r"^(\S[^\n\r:]*):$", line)
+    color_match = re.search(r"^ +(\S[^\n\r:]*): (.+)$", line)
+    if match:
+      key = match.group(1)
+      val = match.group(2).strip()
+      if val.lower() == "true":
+        val = True
+      elif val.lower() == "false":
+        val = False
+      
+      model_metadata[key] = val
+    elif colors_hash_start_match:
+      key = colors_hash_start_match.group(1)
+      model_metadata[key] = OrderedDict()
+      last_custom_colors_hash = model_metadata[key]
+    elif color_match and last_custom_colors_hash is not None:
+      key = color_match.group(1)
+      val = color_match.group(2).strip()
+      last_custom_colors_hash[key] = val
+
+disable_casual_clothes = model_metadata.get("disable_casual_clothes", False)
+if disable_casual_clothes and disable_casual_clothes != "false" and disable_casual_clothes != "False":
+  disable_casual_clothes = True
+else:
+  disable_casual_clothes = False
+
+if not disable_casual_clothes:
+  casual_hair_model_path = os.path.join(blend_file_directory, "..", "katsura", "katsura.blend")
+  if not os.path.isfile(casual_hair_model_path):
+    raise Exception("Casual hair model (katsura.blend) was not found.")
+  casual_clothes_tex_path = os.path.join(blend_file_directory, "..", "linktexbci4.png")
+  if not os.path.isfile(casual_clothes_tex_path):
+    raise Exception("Casual clothes texture (linktexbci4.png) was not found.")
 temp_dir = tempfile.mkdtemp()
 
 # Need to detect if this model is based on Link, or based on Tetra/Medli, since detecting which mesh is the hat/belt buckle is different for Tetra and Medli compared to Link.
@@ -56,12 +90,13 @@ with open(bdl_file_path, "rb") as f:
 scene.objects.active = scene.objects[0]
 bpy.ops.object.mode_set(mode="OBJECT")
 
-# Append the casual hair mesh.
-casual_hair_model_mesh_name = "mesh-0"
-bpy.ops.wm.append(
-  directory=casual_hair_model_path + "\\Object\\", # Needs to have a trailing slash
-  filename=casual_hair_model_mesh_name,
-)
+if not disable_casual_clothes:
+  # Append the casual hair mesh.
+  casual_hair_model_mesh_name = "mesh-0"
+  bpy.ops.wm.append(
+    directory=casual_hair_model_path + "\\Object\\", # Needs to have a trailing slash
+    filename=casual_hair_model_mesh_name,
+  )
 
 # Pose the model so it's not T-posing.
 skeleton_root = scene.objects["skeleton_root"]
@@ -87,20 +122,21 @@ bones["Rclotch_jnt"].rotation_euler = (0.091450, -0.012720, -0.202730)
 bones["RlegB_jnt"].rotation_euler = (0.017057, 0.070484, 0.474697)
 bones["Rfoot_jnt"].rotation_euler = (0.089334, -0.484198, 0.215261)
 
-# Rig the casual hair mesh to the main cl.bdl skeleton, instead of the casual hair's own skeleton, so that it moves with the head when the head is posed.
-skeleton_root = scene.objects["skeleton_root"]
-casual_hair_mesh = bpy.data.objects[casual_hair_model_mesh_name + ".001"]
-casual_hair_mesh.modifiers["Armature"].object = skeleton_root
-casual_hair_mesh.vertex_groups["cl_katsura"].name = "head_jnt"
+if not disable_casual_clothes:
+  # Rig the casual hair mesh to the main cl.bdl skeleton, instead of the casual hair's own skeleton, so that it moves with the head when the head is posed.
+  skeleton_root = scene.objects["skeleton_root"]
+  casual_hair_mesh = bpy.data.objects[casual_hair_model_mesh_name + ".001"]
+  casual_hair_mesh.modifiers["Armature"].object = skeleton_root
+  casual_hair_mesh.vertex_groups["cl_katsura"].name = "head_jnt"
 
-# Finally translate and rotate the casual hair mesh so that it's not down by the player's feet.
-bpy.ops.object.mode_set(mode="EDIT")
-armature = bpy.data.objects["skeleton_root"]
-head_bone = armature.data.edit_bones["head_jnt"]
-casual_hair_mesh.location = head_bone.tail # Will be (0, 83, -0.5) if the head bone has not been moved from vanilla cl.bdl
-casual_hair_mesh.rotation_mode = "XYZ"
-casual_hair_mesh.rotation_euler.rotate_axis("X", math.radians(90.0))
-casual_hair_mesh.rotation_euler.rotate_axis("Y", math.radians(90.0))
+  # Finally translate and rotate the casual hair mesh so that it's not down by the player's feet.
+  bpy.ops.object.mode_set(mode="EDIT")
+  armature = bpy.data.objects["skeleton_root"]
+  head_bone = armature.data.edit_bones["head_jnt"]
+  casual_hair_mesh.location = head_bone.tail # Will be (0, 83, -0.5) if the head bone has not been moved from vanilla cl.bdl
+  casual_hair_mesh.rotation_mode = "XYZ"
+  casual_hair_mesh.rotation_euler.rotate_axis("X", math.radians(90.0))
+  casual_hair_mesh.rotation_euler.rotate_axis("Y", math.radians(90.0))
 
 bpy.ops.object.mode_set(mode="OBJECT")
 
@@ -195,35 +231,6 @@ for tex_header in tex_headers:
       if tex.image.name == tex_image_name:
         tex.extension = wrap_mode
 
-model_metadata = {}
-last_custom_colors_hash = None
-with open(model_metadata_path) as f:
-  for line in f.readlines():
-    match = re.search(r"^(\S[^\n\r:]*): (.+)$", line)
-    colors_hash_start_match = re.search(r"^(\S[^\n\r:]*):$", line)
-    color_match = re.search(r"^ +(\S[^\n\r:]*): (.+)$", line)
-    if match:
-      key = match.group(1)
-      val = match.group(2).strip()
-      if val.lower() == "true":
-        val = True
-      elif val.lower() == "false":
-        val = False
-      
-      model_metadata[key] = val
-    elif colors_hash_start_match:
-      key = colors_hash_start_match.group(1)
-      if key == "hero_custom_colors" or key == "casual_custom_colors":
-        in_custom_colors = True
-      else:
-        in_custom_colors = False
-      model_metadata[key] = OrderedDict()
-      last_custom_colors_hash = model_metadata[key]
-    elif color_match and last_custom_colors_hash is not None:
-      key = color_match.group(1)
-      val = color_match.group(2).strip()
-      last_custom_colors_hash[key] = val
-
 # Increase z-index of the eye and eyebrow meshes (for the masks).
 for mat_name in ["m1eyeL", "m4eyeR", "m8mayuL", "m11mayuR"]:
   mat = bpy.data.materials[mat_name]
@@ -264,12 +271,18 @@ hitomi_pixels = hitomi_image.pixels[:] # Convert the image's pixels to a tuple t
 
 orig_linktexS3TC_path = bpy.data.images["linktexS3TC.png"].filepath
 
-for prefix in ["hero", "casual"]:
+prefix_list = ["hero"]
+if not disable_casual_clothes:
+  prefix_list = ["hero", "casual"]
+
+for prefix in prefix_list:
   color_mask_file_paths = glob.glob(os.path.join(color_masks_dir, "%s_*.png" % prefix))
   
   update_objects_hidden_in_render(prefix)
   
   has_colored_eyebrows = model_metadata.get("has_colored_eyebrows", False)
+  if has_colored_eyebrows == "false" or has_colored_eyebrows == "False":
+    has_colored_eyebrows = False
   hands_color_name = model_metadata.get(prefix + "_hands_color_name", "Skin")
   mouth_color_name = model_metadata.get(prefix + "_mouth_color_name", "Skin")
   hitomi_color_name = model_metadata.get(prefix + "_hitomi_color_name", "Eyes")
@@ -288,10 +301,11 @@ for prefix in ["hero", "casual"]:
       textures_to_mask.append("mayuh.1.png")
     else:
       textures_to_not_mask.append("mayuh.1.png")
-    if curr_color_name == casual_hair_color_name:
-      textures_to_mask.append("katsuraS3TC.png")
-    else:
-      textures_to_not_mask.append("katsuraS3TC.png")
+    if not disable_casual_clothes:
+      if curr_color_name == casual_hair_color_name:
+        textures_to_mask.append("katsuraS3TC.png")
+      else:
+        textures_to_not_mask.append("katsuraS3TC.png")
     if curr_color_name == mouth_color_name:
       textures_to_mask.append("mouthS3TC.1.png")
     else:
@@ -582,11 +596,12 @@ update_objects_hidden_in_render("hero")
 scene.render.filepath = os.path.join(preview_dir, "preview_hero.png")
 bpy.ops.render.render(write_still=True)
 
-# Render the casual clothes preview.
-bpy.data.images["linktexS3TC.png"].filepath = casual_clothes_tex_path
-update_objects_hidden_in_render("casual")
-scene.render.filepath = os.path.join(preview_dir, "preview_casual.png")
-bpy.ops.render.render(write_still=True)
+if not disable_casual_clothes:
+  # Render the casual clothes preview.
+  bpy.data.images["linktexS3TC.png"].filepath = casual_clothes_tex_path
+  update_objects_hidden_in_render("casual")
+  scene.render.filepath = os.path.join(preview_dir, "preview_casual.png")
+  bpy.ops.render.render(write_still=True)
 
 # Delete temp dir.
 shutil.rmtree(temp_dir)


### PR DESCRIPTION
The scripts to generate previews are updated so that if the metadata file has disable_casual_clothes set true only the hero previews are generated. The user does not have to include the casual clothes texture, casual color masks, or the katsura folder in their project in this case.
I tested this with the 2.8 script on vanilla Link, and all results match those of the current script. The 2.79 version has not been tested.